### PR TITLE
Fix ObjectId validation error in note model

### DIFF
--- a/app/models/note.py
+++ b/app/models/note.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel, Field, ConfigDict
+from bson import ObjectId
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 from typing import Optional
 
 
@@ -20,3 +21,9 @@ class Note(NoteBase):
     id: str = Field(alias="_id")
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("id", mode="before")
+    def convert_object_id(cls, v):
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v


### PR DESCRIPTION
## Summary
- handle `ObjectId` conversion when returning database documents

## Testing
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68892df9be78832d9a32e314e33a922d