### PR TITLE
Add user CRUD endpoints

### DIFF
--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -1,0 +1,37 @@
+from bson import ObjectId
+from typing import List, Optional
+
+from ..database import db
+from ..models.user import User, UserCreate, UserUpdate
+
+collection = db["users"]
+
+
+async def create_user(data: UserCreate) -> User:
+    result = await collection.insert_one(data.model_dump())
+    doc = await collection.find_one({"_id": result.inserted_id})
+    return User(**doc)
+
+
+async def list_users() -> List[User]:
+    users: List[User] = []
+    async for doc in collection.find():
+        users.append(User(**doc))
+    return users
+
+
+async def get_user(user_id: str) -> Optional[User]:
+    doc = await collection.find_one({"_id": ObjectId(user_id)})
+    return User(**doc) if doc else None
+
+
+async def update_user(user_id: str, data: UserUpdate) -> Optional[User]:
+    await collection.update_one(
+        {"_id": ObjectId(user_id)}, {"$set": data.model_dump(exclude_unset=True)}
+    )
+    return await get_user(user_id)
+
+
+async def delete_user(user_id: str) -> bool:
+    result = await collection.delete_one({"_id": ObjectId(user_id)})
+    return result.deleted_count == 1

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 from .views.note_view import router as note_router
+from .views.user_view import router as user_router
 
 app = FastAPI(title="Zettelkasten API")
 
 app.include_router(note_router, prefix="/notes", tags=["notes"])
+app.include_router(user_router, prefix="/users", tags=["users"])
 
 
 if __name__ == "__main__":

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,31 @@
+from bson import ObjectId
+from pydantic import BaseModel, Field, ConfigDict, EmailStr, field_validator
+from typing import Optional
+
+
+class UserBase(BaseModel):
+    username: str
+    email: EmailStr
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserUpdate(BaseModel):
+    username: Optional[str] = None
+    email: Optional[EmailStr] = None
+    password: Optional[str] = None
+
+
+class User(UserBase):
+    id: str = Field(alias="_id")
+    password: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("id", mode="before")
+    def convert_object_id(cls, v):
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v

--- a/app/views/user_view.py
+++ b/app/views/user_view.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import List
+
+from ..models.user import User, UserCreate, UserUpdate
+from ..controllers.user_controller import (
+    create_user,
+    list_users,
+    get_user,
+    update_user,
+    delete_user,
+)
+
+router = APIRouter()
+
+
+@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED)
+async def create(data: UserCreate):
+    return await create_user(data)
+
+
+@router.get("/", response_model=List[User])
+async def index():
+    return await list_users()
+
+
+@router.get("/{user_id}", response_model=User)
+async def show(user_id: str):
+    user = await get_user(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.put("/{user_id}", response_model=User)
+async def update(user_id: str, data: UserUpdate):
+    user = await update_user(user_id, data)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def destroy(user_id: str):
+    success = await delete_user(user_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="User not found")


### PR DESCRIPTION
## Summary
- add user Pydantic models
- create controller helpers for users
- expose user API routes
- hook new user router into main app

## Testing
- `python -m compileall -q app`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2386f9f4832da99dca2886bd4338