### PR TITLE
Add user credential verification endpoint

### DIFF
--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -35,3 +35,12 @@ async def update_user(user_id: str, data: UserUpdate) -> Optional[User]:
 async def delete_user(user_id: str) -> bool:
     result = await collection.delete_one({"_id": ObjectId(user_id)})
     return result.deleted_count == 1
+
+
+async def find_user_by_credentials(
+    username: str, email: str, password: str
+) -> Optional[User]:
+    doc = await collection.find_one(
+        {"username": username, "email": email, "password": password}
+    )
+    return User(**doc) if doc else None

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -12,6 +12,10 @@ class UserCreate(UserBase):
     password: str
 
 
+class UserLogin(UserBase):
+    password: str
+
+
 class UserUpdate(BaseModel):
     username: Optional[str] = None
     email: Optional[EmailStr] = None

--- a/app/views/user_view.py
+++ b/app/views/user_view.py
@@ -1,13 +1,14 @@
 from fastapi import APIRouter, HTTPException, status
 from typing import List
 
-from ..models.user import User, UserCreate, UserUpdate
+from ..models.user import User, UserCreate, UserLogin, UserUpdate
 from ..controllers.user_controller import (
     create_user,
     list_users,
     get_user,
     update_user,
     delete_user,
+    find_user_by_credentials,
 )
 
 router = APIRouter()
@@ -44,3 +45,11 @@ async def destroy(user_id: str):
     success = await delete_user(user_id)
     if not success:
         raise HTTPException(status_code=404, detail="User not found")
+
+
+@router.post("/verify", response_model=User)
+async def verify(data: UserLogin):
+    user = await find_user_by_credentials(data.username, data.email, data.password)
+    if user is None:
+        raise HTTPException(status_code=400, detail="User not found")
+    return user


### PR DESCRIPTION
## Summary
- add Pydantic model for user login data
- support credential lookup in controller
- expose `/users/verify` endpoint to check username, email, and password against MongoDB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ae9524308832dbbad16f1ae4bf1e9