### PR TITLE
Rename user_id variables to userId

### DIFF
--- a/app/controllers/note_controller.py
+++ b/app/controllers/note_controller.py
@@ -9,10 +9,10 @@ users_collection = db["users"]
 
 
 async def create_note(data: NoteCreate) -> Note:
-    if not await users_collection.find_one({"_id": ObjectId(data.user_id)}):
+    if not await users_collection.find_one({"_id": ObjectId(data.userId)}):
         raise ValueError("User not found")
 
-    note_data = data.model_dump()
+    note_data = data.model_dump(by_alias=True)
     note_data["user_id"] = ObjectId(note_data["user_id"])
     result = await collection.insert_one(note_data)
     doc = await collection.find_one({"_id": result.inserted_id})
@@ -32,7 +32,7 @@ async def get_note(note_id: str) -> Optional[Note]:
 
 
 async def update_note(note_id: str, data: NoteUpdate) -> Optional[Note]:
-    update_data = data.model_dump(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True, by_alias=True)
     if "user_id" in update_data:
         if not await users_collection.find_one({"_id": ObjectId(update_data["user_id"])}):
             raise ValueError("User not found")

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -20,20 +20,20 @@ async def list_users() -> List[User]:
     return users
 
 
-async def get_user(user_id: str) -> Optional[User]:
-    doc = await collection.find_one({"_id": ObjectId(user_id)})
+async def get_user(userId: str) -> Optional[User]:
+    doc = await collection.find_one({"_id": ObjectId(userId)})
     return User(**doc) if doc else None
 
 
-async def update_user(user_id: str, data: UserUpdate) -> Optional[User]:
+async def update_user(userId: str, data: UserUpdate) -> Optional[User]:
     await collection.update_one(
-        {"_id": ObjectId(user_id)}, {"$set": data.model_dump(exclude_unset=True)}
+        {"_id": ObjectId(userId)}, {"$set": data.model_dump(exclude_unset=True)}
     )
-    return await get_user(user_id)
+    return await get_user(userId)
 
 
-async def delete_user(user_id: str) -> bool:
-    result = await collection.delete_one({"_id": ObjectId(user_id)})
+async def delete_user(userId: str) -> bool:
+    result = await collection.delete_one({"_id": ObjectId(userId)})
     return result.deleted_count == 1
 
 

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -6,7 +6,7 @@ from typing import Optional
 class NoteBase(BaseModel):
     title: str
     content: str
-    user_id: str
+    userId: str = Field(alias="user_id")
 
 
 class NoteCreate(NoteBase):
@@ -16,7 +16,7 @@ class NoteCreate(NoteBase):
 class NoteUpdate(BaseModel):
     title: Optional[str] = None
     content: Optional[str] = None
-    user_id: Optional[str] = None
+    userId: Optional[str] = Field(default=None, alias="user_id")
 
 
 class Note(NoteBase):
@@ -30,7 +30,7 @@ class Note(NoteBase):
             return str(v)
         return v
 
-    @field_validator("user_id", mode="before")
+    @field_validator("userId", mode="before")
     def convert_user_id(cls, v):
         if isinstance(v, ObjectId):
             return str(v)

--- a/app/views/user_view.py
+++ b/app/views/user_view.py
@@ -24,25 +24,25 @@ async def index():
     return await list_users()
 
 
-@router.get("/{user_id}", response_model=User)
-async def show(user_id: str):
-    user = await get_user(user_id)
+@router.get("/{userId}", response_model=User)
+async def show(userId: str):
+    user = await get_user(userId)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return user
 
 
-@router.put("/{user_id}", response_model=User)
-async def update(user_id: str, data: UserUpdate):
-    user = await update_user(user_id, data)
+@router.put("/{userId}", response_model=User)
+async def update(userId: str, data: UserUpdate):
+    user = await update_user(userId, data)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return user
 
 
-@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def destroy(user_id: str):
-    success = await delete_user(user_id)
+@router.delete("/{userId}", status_code=status.HTTP_204_NO_CONTENT)
+async def destroy(userId: str):
+    success = await delete_user(userId)
     if not success:
         raise HTTPException(status_code=404, detail="User not found")
 


### PR DESCRIPTION
## Summary
- Switch snake_case `user_id` fields to camelCase `userId` across models, controllers and views
- Preserve database field naming using Pydantic aliases and alias-based serialization

## Testing
- `python -m py_compile app/models/note.py app/views/user_view.py app/controllers/note_controller.py app/controllers/user_controller.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bd9ca4694832db6efffa0329bfb92