### PR TITLE
Add logging for note creation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
+import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .views.note_view import router as note_router
 from .views.user_view import router as user_router
+
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="Zettelkasten API")
 

--- a/app/views/note_view.py
+++ b/app/views/note_view.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 from typing import List
+import logging
 
 from ..models.note import Note, NoteCreate, NoteUpdate
 from ..controllers.note_controller import (
@@ -12,12 +13,18 @@ from ..controllers.note_controller import (
 
 router = APIRouter()
 
+logger = logging.getLogger(__name__)
+
 
 @router.post("/", response_model=Note, status_code=status.HTTP_201_CREATED)
 async def create(data: NoteCreate):
+    logger.info("POST /notes/ with data: %s", data)
     try:
-        return await create_note(data)
+        note = await create_note(data)
+        logger.info("Note created with id %s", note.id)
+        return note
     except ValueError as e:
+        logger.error("Error creating note: %s", e)
         raise HTTPException(status_code=404, detail=str(e))
 
 


### PR DESCRIPTION
## Summary
- configure base logging for the FastAPI app
- log incoming POST /notes data and outcomes
- add detailed logs during note creation for easier debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bdce7eeb4832dbbf1cb09b587e4ed