### PR TITLE
Print POST /notes parameters

### DIFF
--- a/app/views/note_view.py
+++ b/app/views/note_view.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @router.post("/", response_model=Note, status_code=status.HTTP_201_CREATED)
 async def create(data: NoteCreate):
     logger.info("POST /notes/ with data: %s", data)
+    print(f"POST /notes/ parameters: {data.model_dump()}")
     try:
         note = await create_note(data)
         logger.info("Note created with id %s", note.id)


### PR DESCRIPTION
## Summary
- display POST `/notes/` parameters in console for easier debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be299b5d8832dba621457b03ec944