### PR TITLE
Add favorite collection and endpoints

### DIFF
--- a/app/controllers/favorite_controller.py
+++ b/app/controllers/favorite_controller.py
@@ -1,0 +1,36 @@
+from bson import ObjectId
+import logging
+
+from ..database import db
+from ..models.favorite import Favorite, FavoriteCreate
+
+favorites_collection = db["favorites"]
+notes_collection = db["notes"]
+users_collection = db["users"]
+
+logger = logging.getLogger(__name__)
+
+
+async def add_favorite(data: FavoriteCreate) -> Favorite:
+    logger.info(
+        "Adding favorite for user %s and note %s", data.userId, data.noteId
+    )
+    if not await users_collection.find_one({"_id": ObjectId(data.userId)}):
+        logger.error("User %s not found", data.userId)
+        raise ValueError("User not found")
+    if not await notes_collection.find_one({"_id": ObjectId(data.noteId)}):
+        logger.error("Note %s not found", data.noteId)
+        raise ValueError("Note not found")
+
+    favorite_data = data.model_dump(by_alias=True)
+    favorite_data["userId"] = ObjectId(favorite_data["userId"])
+    favorite_data["noteId"] = ObjectId(favorite_data["noteId"])
+    result = await favorites_collection.insert_one(favorite_data)
+    logger.info("Favorite inserted with id %s", result.inserted_id)
+    doc = await favorites_collection.find_one({"_id": result.inserted_id})
+    return Favorite(**doc)
+
+
+async def delete_favorite(note_id: str) -> bool:
+    result = await favorites_collection.delete_one({"noteId": ObjectId(note_id)})
+    return result.deleted_count == 1

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .views.note_view import router as note_router
 from .views.user_view import router as user_router
+from .views.favorite_view import router as favorite_router
 
 logging.basicConfig(level=logging.INFO)
 
@@ -18,6 +19,7 @@ app.add_middleware(
 
 app.include_router(note_router, prefix="/notes", tags=["notes"])
 app.include_router(user_router, prefix="/users", tags=["users"])
+app.include_router(favorite_router, prefix="/favorites", tags=["favorites"])
 
 
 if __name__ == "__main__":

--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -1,0 +1,29 @@
+from bson import ObjectId
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+
+class FavoriteBase(BaseModel):
+    userId: str
+    noteId: str
+
+
+class FavoriteCreate(FavoriteBase):
+    pass
+
+
+class Favorite(FavoriteBase):
+    id: str = Field(alias="_id")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("id", mode="before")
+    def convert_object_id(cls, v):
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v
+
+    @field_validator("userId", "noteId", mode="before")
+    def convert_ids(cls, v):
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v

--- a/app/views/favorite_view.py
+++ b/app/views/favorite_view.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, HTTPException, status
+import logging
+
+from ..models.favorite import Favorite, FavoriteCreate
+from ..controllers.favorite_controller import add_favorite, delete_favorite
+
+router = APIRouter()
+
+logger = logging.getLogger(__name__)
+
+
+@router.post("/", response_model=Favorite, status_code=status.HTTP_201_CREATED)
+async def create(data: FavoriteCreate):
+    logger.info("POST /favorites/ with data: %s", data)
+    try:
+        favorite = await add_favorite(data)
+        logger.info("Favorite created with id %s", favorite.id)
+        return favorite
+    except ValueError as e:
+        logger.error("Error creating favorite: %s", e)
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.delete("/{note_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def destroy(note_id: str):
+    success = await delete_favorite(note_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Favorite not found")


### PR DESCRIPTION
## Summary
- add Favorite model to track user-note favorites
- implement controller and API routes for creating and deleting favorites
- register favorite routes in the FastAPI app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688bf61b5630832d834faceaa3578d30