### PR TITLE
Add endpoint to list user's favorite notes

### DIFF
--- a/app/controllers/favorite_controller.py
+++ b/app/controllers/favorite_controller.py
@@ -1,8 +1,10 @@
 from bson import ObjectId
 import logging
+from typing import List
 
 from ..database import db
 from ..models.favorite import Favorite, FavoriteCreate
+from ..models.note import Note
 
 favorites_collection = db["favorites"]
 notes_collection = db["notes"]
@@ -29,6 +31,24 @@ async def add_favorite(data: FavoriteCreate) -> Favorite:
     logger.info("Favorite inserted with id %s", result.inserted_id)
     doc = await favorites_collection.find_one({"_id": result.inserted_id})
     return Favorite(**doc)
+
+
+async def get_favorite_notes(user_id: str) -> List[Note]:
+    logger.info("Listing favorite notes for user %s", user_id)
+    if not await users_collection.find_one({"_id": ObjectId(user_id)}):
+        logger.error("User %s not found", user_id)
+        raise ValueError("User not found")
+
+    favorites_cursor = favorites_collection.find({"userId": ObjectId(user_id)})
+    note_ids = [fav["noteId"] async for fav in favorites_cursor]
+    if not note_ids:
+        return []
+
+    notes_cursor = notes_collection.find({"_id": {"$in": note_ids}})
+    notes: List[Note] = []
+    async for doc in notes_cursor:
+        notes.append(Note(**doc))
+    return notes
 
 
 async def delete_favorite(note_id: str) -> bool:

--- a/app/views/favorite_view.py
+++ b/app/views/favorite_view.py
@@ -1,8 +1,14 @@
 from fastapi import APIRouter, HTTPException, status
+from typing import List
 import logging
 
 from ..models.favorite import Favorite, FavoriteCreate
-from ..controllers.favorite_controller import add_favorite, delete_favorite
+from ..models.note import Note
+from ..controllers.favorite_controller import (
+    add_favorite,
+    delete_favorite,
+    get_favorite_notes,
+)
 
 router = APIRouter()
 
@@ -18,6 +24,16 @@ async def create(data: FavoriteCreate):
         return favorite
     except ValueError as e:
         logger.error("Error creating favorite: %s", e)
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/{user_id}", response_model=List[Note])
+async def index(user_id: str):
+    logger.info("GET /favorites/%s", user_id)
+    try:
+        return await get_favorite_notes(user_id)
+    except ValueError as e:
+        logger.error("Error listing favorites for user %s: %s", user_id, e)
         raise HTTPException(status_code=404, detail=str(e))
 
 


### PR DESCRIPTION
## Summary
- allow retrieving a user's favorite notes via a new controller function
- expose GET /favorites/{user_id} endpoint to fetch all favorite notes for a user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bf814dc80832da86ed43ec7bc1dad