### PR TITLE
Add DynamoDB-backed tag endpoints

### DIFF
--- a/app/controllers/tag_controller.py
+++ b/app/controllers/tag_controller.py
@@ -1,0 +1,64 @@
+import os
+import logging
+from typing import List, Optional
+
+import boto3
+
+from ..models.tag import Tag, TagCreate, TagUpdate
+
+logger = logging.getLogger(__name__)
+
+
+dynamodb = boto3.resource(
+    "dynamodb",
+    region_name=os.getenv("AWS_DEFAULT_REGION"),
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+)
+
+table_name = os.getenv("DYNAMO_TABLE", "zetteltasken-tags")
+table = dynamodb.Table(table_name)
+
+
+async def create_tag(data: TagCreate) -> Tag:
+    logger.info("Creating tag '%s'", data.tag)
+    item = data.model_dump()
+    table.put_item(Item=item)
+    return Tag(**item)
+
+
+async def list_tags() -> List[Tag]:
+    logger.info("Listing all tags")
+    response = table.scan()
+    items = response.get("Items", [])
+    return [Tag(**item) for item in items]
+
+
+async def get_tag(tag_name: str) -> Optional[Tag]:
+    logger.info("Fetching tag '%s'", tag_name)
+    response = table.get_item(Key={"tag": tag_name})
+    item = response.get("Item")
+    return Tag(**item) if item else None
+
+
+async def update_tag(tag_name: str, data: TagUpdate) -> Optional[Tag]:
+    logger.info("Updating tag '%s'", tag_name)
+    update_data = data.model_dump(exclude_unset=True)
+    if not update_data:
+        return await get_tag(tag_name)
+    update_expr = "SET " + ", ".join(f"#{k}=:{k}" for k in update_data)
+    expr_attr_names = {f"#{k}": k for k in update_data}
+    expr_attr_values = {f":{k}": v for k, v in update_data.items()}
+    table.update_item(
+        Key={"tag": tag_name},
+        UpdateExpression=update_expr,
+        ExpressionAttributeNames=expr_attr_names,
+        ExpressionAttributeValues=expr_attr_values,
+    )
+    return await get_tag(tag_name)
+
+
+async def delete_tag(tag_name: str) -> bool:
+    logger.info("Deleting tag '%s'", tag_name)
+    response = table.delete_item(Key={"tag": tag_name}, ReturnValues="ALL_OLD")
+    return "Attributes" in response

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .views.note_view import router as note_router
 from .views.user_view import router as user_router
 from .views.favorite_view import router as favorite_router
+from .views.tag_view import router as tag_router
 
 logging.basicConfig(level=logging.INFO)
 
@@ -20,6 +21,7 @@ app.add_middleware(
 app.include_router(note_router, prefix="/notes", tags=["notes"])
 app.include_router(user_router, prefix="/users", tags=["users"])
 app.include_router(favorite_router, prefix="/favorites", tags=["favorites"])
+app.include_router(tag_router, prefix="/tags", tags=["tags"])
 
 
 if __name__ == "__main__":

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class TagBase(BaseModel):
+    description: Optional[str] = None
+
+
+class TagCreate(TagBase):
+    tag: str
+
+
+class TagUpdate(BaseModel):
+    description: Optional[str] = None
+
+
+class Tag(TagCreate):
+    pass

--- a/app/views/tag_view.py
+++ b/app/views/tag_view.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import List
+import logging
+
+from ..models.tag import Tag, TagCreate, TagUpdate
+from ..controllers.tag_controller import (
+    create_tag,
+    list_tags,
+    get_tag,
+    update_tag,
+    delete_tag,
+)
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/", response_model=Tag, status_code=status.HTTP_201_CREATED)
+async def create(data: TagCreate):
+    logger.info("POST /tags/ with data: %s", data)
+    return await create_tag(data)
+
+
+@router.get("/", response_model=List[Tag])
+async def index():
+    return await list_tags()
+
+
+@router.get("/{tag}", response_model=Tag)
+async def show(tag: str):
+    result = await get_tag(tag)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return result
+
+
+@router.put("/{tag}", response_model=Tag)
+async def update(tag: str, data: TagUpdate):
+    result = await update_tag(tag, data)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return result
+
+
+@router.delete("/{tag}", status_code=status.HTTP_204_NO_CONTENT)
+async def destroy(tag: str):
+    success = await delete_tag(tag)
+    if not success:
+        raise HTTPException(status_code=404, detail="Tag not found")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ motor
 pydantic
 pydantic-settings
 email-validator
+boto3


### PR DESCRIPTION
## Summary
- add Tag model and controllers backed by DynamoDB
- expose /tags routes for creating, listing, updating, and deleting tags
- include boto3 dependency and wire router into main app

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement boto3)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c26d7f39c832d8c2a4935af416e64