### PR TITLE
Use only username and password for login

### DIFF
--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -38,9 +38,9 @@ async def delete_user(userId: str) -> bool:
 
 
 async def find_user_by_credentials(
-    username: str, email: str, password: str
+    username: str, password: str
 ) -> Optional[User]:
     doc = await collection.find_one(
-        {"username": username, "email": email, "password": password}
+        {"username": username, "password": password}
     )
     return User(**doc) if doc else None

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -12,7 +12,8 @@ class UserCreate(UserBase):
     password: str
 
 
-class UserLogin(UserBase):
+class UserLogin(BaseModel):
+    username: str
     password: str
 
 

--- a/app/views/user_view.py
+++ b/app/views/user_view.py
@@ -49,7 +49,7 @@ async def destroy(userId: str):
 
 @router.post("/verify", response_model=User)
 async def verify(data: UserLogin):
-    user = await find_user_by_credentials(data.username, data.email, data.password)
+    user = await find_user_by_credentials(data.username, data.password)
     if user is None:
         raise HTTPException(status_code=400, detail="User not found")
     return user


### PR DESCRIPTION
## Summary
- remove email from `UserLogin` model and credential lookup
- update verify route to authenticate with just username and password

## Testing
- `pytest`
- `python -m py_compile app/controllers/user_controller.py app/views/user_view.py app/models/user.py`

------
https://chatgpt.com/codex/tasks/task_e_688cc23bacb0832dad75edb761956edd