### PR TITLE
Add endpoint for listing notes by user

### DIFF
--- a/app/controllers/note_controller.py
+++ b/app/controllers/note_controller.py
@@ -32,6 +32,19 @@ async def list_notes() -> List[Note]:
     return notes
 
 
+async def list_notes_by_user(user_id: str) -> List[Note]:
+    logger.info("Listing notes for user %s", user_id)
+    if not await users_collection.find_one({"_id": ObjectId(user_id)}):
+        logger.error("User %s not found", user_id)
+        raise ValueError("User not found")
+
+    notes: List[Note] = []
+    cursor = collection.find({"userId": ObjectId(user_id)})
+    async for doc in cursor:
+        notes.append(Note(**doc))
+    return notes
+
+
 async def get_note(note_id: str) -> Optional[Note]:
     doc = await collection.find_one({"_id": ObjectId(note_id)})
     return Note(**doc) if doc else None

--- a/app/views/note_view.py
+++ b/app/views/note_view.py
@@ -6,6 +6,7 @@ from ..models.note import Note, NoteCreate, NoteUpdate
 from ..controllers.note_controller import (
     create_note,
     list_notes,
+    list_notes_by_user,
     get_note,
     update_note,
     delete_note,
@@ -32,6 +33,16 @@ async def create(data: NoteCreate):
 @router.get("/", response_model=List[Note])
 async def index():
     return await list_notes()
+
+
+@router.get("/user/{user_id}", response_model=List[Note])
+async def by_user(user_id: str):
+    logger.info("GET /notes/user/%s", user_id)
+    try:
+        return await list_notes_by_user(user_id)
+    except ValueError as e:
+        logger.error("Error listing notes for user %s: %s", user_id, e)
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @router.get("/{note_id}", response_model=Note)


### PR DESCRIPTION
## Summary
- allow fetching notes for a specific user with new `/notes/user/{user_id}` endpoint
- add `list_notes_by_user` controller to retrieve notes for existing users

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d235743a4832d9e0216b6cb9259c0