### PR TITLE
Refactor favorites collection to use note arrays per user

### DIFF
--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -1,29 +1,27 @@
 from bson import ObjectId
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing import List
 
 
-class FavoriteBase(BaseModel):
+class FavoriteCreate(BaseModel):
     userId: str
     noteId: str
 
 
-class FavoriteCreate(FavoriteBase):
-    pass
-
-
-class Favorite(FavoriteBase):
-    id: str = Field(alias="_id")
+class Favorite(BaseModel):
+    userId: str
+    noteIds: List[str] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
 
-    @field_validator("id", mode="before")
-    def convert_object_id(cls, v):
+    @field_validator("userId", mode="before")
+    def convert_user_id(cls, v):
         if isinstance(v, ObjectId):
             return str(v)
         return v
 
-    @field_validator("userId", "noteId", mode="before")
-    def convert_ids(cls, v):
-        if isinstance(v, ObjectId):
-            return str(v)
+    @field_validator("noteIds", mode="before")
+    def convert_note_ids(cls, v):
+        if isinstance(v, list):
+            return [str(i) if isinstance(i, ObjectId) else i for i in v]
         return v

--- a/app/views/favorite_view.py
+++ b/app/views/favorite_view.py
@@ -20,7 +20,7 @@ async def create(data: FavoriteCreate):
     logger.info("POST /favorites/ with data: %s", data)
     try:
         favorite = await add_favorite(data)
-        logger.info("Favorite created with id %s", favorite.id)
+        logger.info("Favorite list updated for user %s", favorite.userId)
         return favorite
     except ValueError as e:
         logger.error("Error creating favorite: %s", e)


### PR DESCRIPTION
## Summary
- replace per-note favorite docs with user documents containing `noteIds` arrays
- update favorite controller to add, list, and delete note IDs within a user's favorites
- adjust favorite model and view logging for new structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d39aa2acc832db72c474e89e34d66