### PR TITLE
Refactor tag endpoints to use tag_id and add user listing

### DIFF
--- a/app/controllers/tag_controller.py
+++ b/app/controllers/tag_controller.py
@@ -1,8 +1,9 @@
 import os
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import boto3
+from boto3.dynamodb.conditions import Attr
 
 from ..models.tag import Tag, TagCreate, TagUpdate
 
@@ -21,48 +22,51 @@ table = dynamodb.Table(table_name)
 
 
 async def create_tag(data: TagCreate) -> Tag:
-    logger.info("Creating tags for user '%s'", data.userId)
+    logger.info("Creating tag '%s' for user '%s'", data.tag_id, data.userId)
     item = data.model_dump()
     table.put_item(Item=item)
     return Tag(**item)
 
 
-async def list_tags() -> Dict[str, List[str]]:
+async def list_tags() -> List[Tag]:
     logger.info("Listing all tags")
     response = table.scan()
     items = response.get("Items", [])
-    return {item["userId"]: item.get("tags", []) for item in items}
+    return [Tag(**item) for item in items]
 
 
-async def get_tag(user_id: str) -> Optional[Dict[str, List[str]]]:
-    logger.info("Fetching tags for user '%s'", user_id)
-    response = table.get_item(Key={"userId": user_id})
+async def list_user_tags(user_id: str) -> List[Tag]:
+    logger.info("Listing tags for user '%s'", user_id)
+    response = table.scan(FilterExpression=Attr("userId").eq(user_id))
+    items = response.get("Items", [])
+    return [Tag(**item) for item in items]
+
+
+async def get_tag(tag_id: str) -> Optional[Tag]:
+    logger.info("Fetching tag '%s'", tag_id)
+    response = table.get_item(Key={"tag_id": tag_id})
     item = response.get("Item")
     if item:
-        return {user_id: item.get("tags", [])}
+        return Tag(**item)
     return None
 
 
-async def update_tag(user_id: str, data: TagUpdate) -> Optional[Tag]:
-    logger.info("Updating tags for user '%s'", user_id)
+async def update_tag(tag_id: str, data: TagUpdate) -> Optional[Tag]:
+    logger.info("Updating tag '%s'", tag_id)
     update_data = data.model_dump(exclude_unset=True)
     if not update_data:
-        existing = await get_tag(user_id)
-        if existing:
-            return Tag(userId=user_id, tags=existing[user_id])
-        return None
+        return await get_tag(tag_id)
+    update_expression = "SET " + ", ".join(f"{k}=:{k}" for k in update_data.keys())
+    expression_values = {f":{k}": v for k, v in update_data.items()}
     table.update_item(
-        Key={"userId": user_id},
-        UpdateExpression="SET tags=:tags",
-        ExpressionAttributeValues={":tags": update_data["tags"]},
+        Key={"tag_id": tag_id},
+        UpdateExpression=update_expression,
+        ExpressionAttributeValues=expression_values,
     )
-    updated = await get_tag(user_id)
-    if updated:
-        return Tag(userId=user_id, tags=updated[user_id])
-    return None
+    return await get_tag(tag_id)
 
 
-async def delete_tag(user_id: str) -> bool:
-    logger.info("Deleting tags for user '%s'", user_id)
-    response = table.delete_item(Key={"userId": user_id}, ReturnValues="ALL_OLD")
+async def delete_tag(tag_id: str) -> bool:
+    logger.info("Deleting tag '%s'", tag_id)
+    response = table.delete_item(Key={"tag_id": tag_id}, ReturnValues="ALL_OLD")
     return "Attributes" in response

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -1,17 +1,22 @@
 from pydantic import BaseModel
-from typing import List
+from typing import Optional
 
 
 class TagBase(BaseModel):
-    tags: List[str]
+    title: str
+    description: str
+    parent_note_id: str
 
 
 class TagCreate(TagBase):
     userId: str
+    tag_id: str
 
 
 class TagUpdate(BaseModel):
-    tags: List[str]
+    title: Optional[str] = None
+    description: Optional[str] = None
+    parent_note_id: Optional[str] = None
 
 
 class Tag(TagCreate):

--- a/app/views/tag_view.py
+++ b/app/views/tag_view.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, HTTPException, status
-from typing import Dict, List
+from typing import List
 import logging
 
 from ..models.tag import Tag, TagCreate, TagUpdate
 from ..controllers.tag_controller import (
     create_tag,
     list_tags,
+    list_user_tags,
     get_tag,
     update_tag,
     delete_tag,
@@ -21,29 +22,34 @@ async def create(data: TagCreate):
     return await create_tag(data)
 
 
-@router.get("/", response_model=Dict[str, List[str]])
+@router.get("/", response_model=List[Tag])
 async def index():
     return await list_tags()
 
 
-@router.get("/{user_id}", response_model=Dict[str, List[str]])
-async def show(user_id: str):
-    result = await get_tag(user_id)
+@router.get("/user/{user_id}", response_model=List[Tag])
+async def user_tags(user_id: str):
+    return await list_user_tags(user_id)
+
+
+@router.get("/{tag_id}", response_model=Tag)
+async def show(tag_id: str):
+    result = await get_tag(tag_id)
     if result is None:
-        raise HTTPException(status_code=404, detail="User tags not found")
+        raise HTTPException(status_code=404, detail="Tag not found")
     return result
 
 
-@router.put("/{user_id}", response_model=Tag)
-async def update(user_id: str, data: TagUpdate):
-    result = await update_tag(user_id, data)
+@router.put("/{tag_id}", response_model=Tag)
+async def update(tag_id: str, data: TagUpdate):
+    result = await update_tag(tag_id, data)
     if result is None:
-        raise HTTPException(status_code=404, detail="User tags not found")
+        raise HTTPException(status_code=404, detail="Tag not found")
     return result
 
 
-@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def destroy(user_id: str):
-    success = await delete_tag(user_id)
+@router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def destroy(tag_id: str):
+    success = await delete_tag(tag_id)
     if not success:
-        raise HTTPException(status_code=404, detail="User tags not found")
+        raise HTTPException(status_code=404, detail="Tag not found")


### PR DESCRIPTION
## Summary
- refactor tag model to include `userId`, `tag_id`, `title`, `description`, and `parent_note_id`
- expose tag CRUD routes keyed by `tag_id`
- add `GET /tags/user/{user_id}` endpoint to list a user's tags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d80c76250832d83fe1c6a6c4eaa5b