### PR TITLE
Generate uuid4 IDs for new tags

### DIFF
--- a/app/controllers/tag_controller.py
+++ b/app/controllers/tag_controller.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from typing import List, Optional
+from uuid import uuid4
 
 import boto3
 from boto3.dynamodb.conditions import Attr
@@ -22,8 +23,9 @@ table = dynamodb.Table(table_name)
 
 
 async def create_tag(data: TagCreate) -> Tag:
-    logger.info("Creating tag '%s' for user '%s'", data.tag_id, data.userId)
-    item = data.model_dump()
+    tag_id = str(uuid4())
+    logger.info("Creating tag '%s' for user '%s'", tag_id, data.userId)
+    item = {**data.model_dump(), "tag_id": tag_id}
     table.put_item(Item=item)
     return Tag(**item)
 

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -10,7 +10,6 @@ class TagBase(BaseModel):
 
 class TagCreate(TagBase):
     userId: str
-    tag_id: str
 
 
 class TagUpdate(BaseModel):
@@ -20,4 +19,4 @@ class TagUpdate(BaseModel):
 
 
 class Tag(TagCreate):
-    pass
+    tag_id: str


### PR DESCRIPTION
## Summary
- Generate a random uuid4 for tag_id in tag controller
- Simplify tag models to only require userId on creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d926c5114832d88645f6c3d8ff18d