### PR TITLE
feat: add optional note parent reference

### DIFF
--- a/app/models/note.py
+++ b/app/models/note.py
@@ -7,6 +7,7 @@ class NoteBase(BaseModel):
     title: str
     content: str
     userId: str
+    note_parent_id: Optional[str] = None
 
 
 class NoteCreate(NoteBase):
@@ -17,6 +18,7 @@ class NoteUpdate(BaseModel):
     title: Optional[str] = None
     content: Optional[str] = None
     userId: Optional[str] = None
+    note_parent_id: Optional[str] = None
 
 
 class Note(NoteBase):
@@ -32,6 +34,12 @@ class Note(NoteBase):
 
     @field_validator("userId", mode="before")
     def convert_userId(cls, v):
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v
+
+    @field_validator("note_parent_id", mode="before")
+    def convert_note_parent_id(cls, v):
         if isinstance(v, ObjectId):
             return str(v)
         return v


### PR DESCRIPTION
## Summary
- allow notes to optionally reference a parent note via `note_parent_id`
- convert `note_parent_id` ObjectIds to strings in responses
- handle `note_parent_id` when creating or updating notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689013baaef0832db06203c92237b1ab